### PR TITLE
Add README.md note about CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ poetry invoke lint
 poetry inv lint
 ```
 
+### Using command-line options
+
+If passing any command-line options to `poetry invoke`, 
+these may have to be separated by `--` to indicate that the command-line options should be passed to `poetry invoke` instead of `poetry`.
+
+For instance to list all commands available to invoke, `poetry invoke --list` would fail as it is providing `--list` to `poetry`. Instead you should use `poetry invoke -- --list`. 
+
+This works similarly for commands, for example `poetry invoke cmd -- --opt 1` for a command `cmd` that takes an option `--opt`.
+
 ## Publishing
 
 To publish a new version create a release from `main` (after pull request).


### PR DESCRIPTION
Hey there! Really love this package.

I noticed that when you try to pass in any command-line options (at least on `zsh`), you might need to separate them with a `--` or you'll run into problems with those options being provided to `poetry` instead of `poetry invoke/inv`.

Let me know what you think!